### PR TITLE
docs: production-gate is a frozen branch, not a nonexistent one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@
 # (pass an older git ref to roll back).
 #
 # Requirements:
-# - The Vercel project's Production Branch must be set to a branch that
-#   intentionally does not exist (e.g. `production-gate`) so pushes to main
-#   only create preview deployments. See docs/releasing.md
+# - The Vercel project's Production Branch must be set to `production-gate`, a
+#   frozen branch whose ruleset blocks all pushes, so pushes to main only
+#   create preview deployments. See docs/releasing.md
 # - The `Production` environment must provide the VERCEL_TOKEN, VERCEL_ORG_ID
 #   and VERCEL_PROJECT_ID secrets
 

--- a/.vercel/ignore-step.sh
+++ b/.vercel/ignore-step.sh
@@ -5,9 +5,9 @@
 echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF";
 
 # Always build production deployments. Git pushes never create production
-# deployments (the project's Production Branch points to a branch that
-# intentionally doesn't exist); these are only created by the Release workflow
-# (.github/workflows/release.yml) through the Vercel CLI.
+# deployments (the project's Production Branch points to `production-gate`, a
+# frozen branch whose ruleset blocks all pushes); these are only created by the
+# Release workflow (.github/workflows/release.yml) through the Vercel CLI.
 if [[ "$VERCEL_ENV" == "production" ]] ; then
   echo "✅ - Build can proceed (production release)"
   exit 1;

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,7 +2,7 @@
 
 There is a single branch (`main`). Pushes to `main` never deploy to production on their own:
 
-- Vercel only creates _preview_ deployments for pushes (the project's Production Branch points to `production-gate`, a branch that intentionally doesn't exist)
+- Vercel only creates _preview_ deployments for pushes (the project's Production Branch points to `production-gate`, a frozen branch whose ruleset blocks all pushes — Vercel requires the Production Branch to exist in the repository)
 - The Lambda functions are only deployed by the [Release workflow](../.github/workflows/release.yml) (or manually via the [Deploy Lambda functions workflow](../.github/workflows/deploy-lambda-functions.yml))
 
 ## Release workflow

--- a/docs/setup-test-and-production.md
+++ b/docs/setup-test-and-production.md
@@ -100,8 +100,9 @@
 1. Set `Root Directory` to `pnpm-monorepo/apps/app` and keep "Include source files outside of the Root Directory in the Build Step" enabled (required for the workspace lockfile and `pnpm-workspace.yaml` at the `pnpm-monorepo` root)
 2. Add the environment variable `ENABLE_EXPERIMENTAL_COREPACK=1` so Vercel uses the pinned pnpm version. Vercel reads the `packageManager` field from the package.json at the repository root (not the Root Directory), so the pin lives in `/package.json` (kept in sync with `pnpm-monorepo/package.json`)
 3. The `Ignored Build Step` is configured in code via `pnpm-monorepo/apps/app/vercel.json` (it runs `.vercel/ignore-step.sh` from the repository root); remove any `Ignored Build Step` override in the dashboard
-4. Set `Production Branch` (Settings > Environments > Production) to `production-gate`. This branch intentionally doesn't exist: pushes to `main` only create preview deployments, and production deployments are only created by the [Release workflow](./releasing.md)
-5. Create an access token (Account Settings > Tokens) and store it together with the IDs from the project's settings as the `VERCEL_TOKEN`, `VERCEL_ORG_ID` (team ID) and `VERCEL_PROJECT_ID` secrets of the `Production` GitHub environment
+4. Create the frozen `production-gate` branch and a ruleset that blocks all pushes to it (no bypass actors). Vercel requires the Production Branch to exist in the repository, but this branch must never move: an accidental push to it would trigger a git-driven production deployment
+5. Set `Production Branch` (Settings > Environments > Production) to `production-gate`: pushes to `main` then only create preview deployments, and production deployments are only created by the [Release workflow](./releasing.md)
+6. Create an access token (Account Settings > Tokens) and store it together with the IDs from the project's settings as the `VERCEL_TOKEN`, `VERCEL_ORG_ID` (team ID) and `VERCEL_PROJECT_ID` secrets of the `Production` GitHub environment
 
 ## 8. Left over
 


### PR DESCRIPTION
Vercel validates that the Production Branch exists in the connected repository, so the gate branch has to exist. A ruleset without bypass actors blocks all pushes to it.